### PR TITLE
Updated examples to show the use of config variables

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -46,7 +46,8 @@ Parameters are identical to `recognize()`.
 ```js
 const recognize = tesseract.withOptions({
     psm: 4,
-    language: [ 'fin', 'eng' ]
+    language: [ 'fin', 'eng' ],
+    config: ['tessedit_do_invert=0']
 })
 
 recognize(`${__dirname}/image.png`, (err, text) => { /* ... */ })


### PR DESCRIPTION
It was not clear from the docs, that you dont need to pass "-c" as an argument to the config prop. 
Nice feature btw.