### PR TITLE
fixed syntax mistake in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Node.js wrapper for Tesseract OCR CLI.",
   "main": "lib/recognize.js",
   "exports": {
-    "require": "lib/recognize.js",
-    "import": "lib/recognize.mjs"
+    "require": "./lib/recognize.js",
+    "import": "./lib/recognize.mjs"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
the above change fixes error:

Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "lib/recognize.js" defined in the package config .../tesseractocr/package.json

Explanation:
Node.js 13 introduced more rules to the package.json
the main export targets now have to begin with ^./